### PR TITLE
add automated relations calculation and disable type prop

### DIFF
--- a/src/ODataMockGenerator.js
+++ b/src/ODataMockGenerator.js
@@ -32,18 +32,18 @@ import * as metadataExtract from "./metadataExtract.js";
 
 /**
  * OData Mock Data Generator
- * 
+ *
  */
 export class ODataMockGenerator {
   /**
    * @constructor
-   * @param {string} metadata OData metadata XML 
+   * @param {string} metadata OData metadata XML
    * @param {Object} [options={}] Generation options and rules
    * @param {number} [options.defaultLengthOfEntitySets=30] Number of entities to generate for each entity set
    * @param {string} [options.mockDataRootURI=""] Root URI which prefixes __metadata.uri property in the generated entities
    * @param {Object} [options.rules={}] Additional rules
    * @param {string[]} [options.rules.skipMockGeneration=[]] Do not generate data for the given entity sets
-   * @param {string[]} [options.rules.distinctValues=[]] Generate only distinct entries (based on the key properties) for the given entity sets 
+   * @param {string[]} [options.rules.distinctValues=[]] Generate only distinct entries (based on the key properties) for the given entity sets
    * @param {Object} [options.rules.predefined={}] Predefined values for the given entities, see README
    * @param {Object} [options.rules.variables={}] Variables to use in "predefined" rules, see README
    * @param {Object} [options.rules.faker={}] Faker.js methods used to generate data for given properties, see README
@@ -74,6 +74,12 @@ export class ODataMockGenerator {
     this._predefinedChosenValues = {};
     this._dataGenerator = new DataGenerator();
 
+    this._relationships = options.rules.relationships || {};
+    this._includeTypeAttribute =
+      options.includeTypeAttribute !== undefined
+        ? options.includeTypeAttribute
+        : true;
+
     try {
       this._metdataXMLDocument = parseXML(metadata);
     } catch (error) {
@@ -82,8 +88,32 @@ export class ODataMockGenerator {
   }
 
   /**
-   * Generates mock data based on the metadata and options passed to the constructor 
-   * 
+   *
+   * Generates relationships between entities mentioned in the configuration
+   *
+   * @param {Object} oMockData incoming data
+   */
+  _applyRelationships(oMockData) {
+    console.log("_applyRelationships", this._relationships);
+    for (const [entity, relations] of Object.entries(this._relationships)) {
+      if (oMockData[entity]) {
+        oMockData[entity].forEach((entityData) => {
+          for (const [property, relation] of Object.entries(relations)) {
+            const relatedData = oMockData[relation.reference];
+            if (relatedData) {
+              const relatedEntity =
+                relatedData[Math.floor(Math.random() * relatedData.length)];
+              entityData[property] = relatedEntity[relation.key];
+            }
+          }
+        });
+      }
+    }
+  }
+
+  /**
+   * Generates mock data based on the metadata and options passed to the constructor
+   *
    * @returns {Object} Generated data in form { EntitySet1: [{ ..properties.. }], EntitySet2: [{ .. properties.. }] }
    */
   createMockData() {
@@ -92,16 +122,21 @@ export class ODataMockGenerator {
 
     //exclude adjustments
     this._skipMockGeneration.forEach((element) => {
-      if (entitySetNames.find((name) => {
+      if (
+        entitySetNames.find((name) => {
           return name === element;
-        })) {
-
+        })
+      ) {
         delete entitySets[element];
       }
     });
 
-    this._mEntityTypes = metadataExtract.findEntityTypes(this._metdataXMLDocument);
-    this._mComplexTypes = metadataExtract.findComplexTypes(this._metdataXMLDocument);
+    this._mEntityTypes = metadataExtract.findEntityTypes(
+      this._metdataXMLDocument
+    );
+    this._mComplexTypes = metadataExtract.findComplexTypes(
+      this._metdataXMLDocument
+    );
     this._generateMockdata(entitySets);
 
     return this._oMockdata;
@@ -115,8 +150,11 @@ export class ODataMockGenerator {
       const mEntitySet = {};
       const oEntitySet = mEntitySets[sEntitySetName];
       mEntitySet[oEntitySet.name] = oEntitySet;
-      oMockData[sEntitySetName] = this._generateODataMockdataForEntitySet(mEntitySet)[sEntitySetName];
+      oMockData[sEntitySetName] =
+        this._generateODataMockdataForEntitySet(mEntitySet)[sEntitySetName];
     }
+
+    this._applyRelationships(oMockData);
 
     // changing the values if there is a referential constraint
     for (const sEntitySetName in mEntitySets) {
@@ -134,17 +172,28 @@ export class ODataMockGenerator {
             // copy the value from the principle to the dependant;
             const oEntity = oMockData[sEntitySetName][i];
 
-            if (this._predefinedValuesConfig[oNavProp.name] &&
-              this._predefinedValuesConfig[oNavProp.name][oNavProp.to.propRef[j]]) {
-              const chosenValues = this._predefinedChosenValues[oNavProp.name][oNavProp.to.propRef[j]];
-              oEntity[oNavProp.from.propRef[j]] = chosenValues[Math.floor(Math.random() * chosenValues.length)];
+            if (
+              this._predefinedValuesConfig[oNavProp.name] &&
+              this._predefinedValuesConfig[oNavProp.name][
+                oNavProp.to.propRef[j]
+              ]
+            ) {
+              const chosenValues =
+                this._predefinedChosenValues[oNavProp.name][
+                  oNavProp.to.propRef[j]
+                ];
+              oEntity[oNavProp.from.propRef[j]] =
+                chosenValues[Math.floor(Math.random() * chosenValues.length)];
             } else {
               try {
-                oMockData[oNavProp.to.entitySet][i][oNavProp.to.propRef[j]] = oEntity[oNavProp.from.propRef[j]];
+                oMockData[oNavProp.to.entitySet][i][oNavProp.to.propRef[j]] =
+                  oEntity[oNavProp.from.propRef[j]];
               } catch (error) {
-                throw new Error(`Could not find a respective entry in ${oNavProp.to.entitySet} ` +
-                  `to update its value from a navigation related property ${oNavProp.from.propRef} ` +
-                  `in ${sEntitySetName}. Check it the target entity set generation is not limited or skipped`);
+                throw new Error(
+                  `Could not find a respective entry in ${oNavProp.to.entitySet} ` +
+                    `to update its value from a navigation related property ${oNavProp.from.propRef} ` +
+                    `in ${sEntitySetName}. Check it the target entity set generation is not limited or skipped`
+                );
               }
             }
           }
@@ -152,22 +201,38 @@ export class ODataMockGenerator {
       }
     }
 
-    // set URIs 
+    // set URIs
     for (const sEntitySetName in mEntitySets) {
       const oEntitySet = mEntitySets[sEntitySetName];
       oMockData[sEntitySetName].forEach((oEntry) => {
         // add the metadata for the entry
         oEntry.__metadata = {
-          uri: sRootUri + sEntitySetName + "(" + this._createKeysString(oEntitySet, oEntry) + ")",
-          type: oEntitySet.schema + "." + oEntitySet.type
+          uri:
+            sRootUri +
+            sEntitySetName +
+            "(" +
+            this._createKeysString(oEntitySet, oEntry) +
+            ")",
+          type: oEntitySet.schema + "." + oEntitySet.type,
         };
         // add the navigation properties
-        for (const sKey in oEntitySet.navprops) {
-          oEntry[sKey] = {
-            __deferred: {
-              uri: sRootUri + sEntitySetName + "(" + this._createKeysString(oEntitySet, oEntry) + ")/" + sKey
-            }
-          };
+        if (this._includeTypeAttribute) {
+          for (const sKey in oEntitySet.navprops) {
+            oEntry[sKey] = {
+              __deferred: {
+                uri:
+                  sRootUri +
+                  sEntitySetName +
+                  "(" +
+                  this._createKeysString(oEntitySet, oEntry) +
+                  ")/" +
+                  sKey,
+              },
+            };
+          }
+        } else {
+          // remove the type attribute
+          delete oEntry.type;
         }
       });
     }
@@ -249,7 +314,12 @@ export class ODataMockGenerator {
 
     for (let i = 0; i < oEntityType.properties.length; i++) {
       const oProperty = oEntityType.properties[i];
-      oEntity[oProperty.name] = this._generatePropertyValue(oProperty, iIndex, oEntityType, oEntity);
+      oEntity[oProperty.name] = this._generatePropertyValue(
+        oProperty,
+        iIndex,
+        oEntityType,
+        oEntity
+      );
     }
 
     return oEntity;
@@ -262,9 +332,10 @@ export class ODataMockGenerator {
     }
 
     //predefined?
-    if (this._predefinedValuesConfig[entityType.name] &&
-      this._predefinedValuesConfig[entityType.name][property.name]) {
-
+    if (
+      this._predefinedValuesConfig[entityType.name] &&
+      this._predefinedValuesConfig[entityType.name][property.name]
+    ) {
       if (!this._predefinedChosenValues[entityType.name]) {
         this._predefinedChosenValues[entityType.name] = {};
       }
@@ -273,15 +344,22 @@ export class ODataMockGenerator {
         this._predefinedChosenValues[entityType.name][property.name] = [];
       }
 
-      const propertyConfig = this._predefinedValuesConfig[entityType.name][property.name];
+      const propertyConfig =
+        this._predefinedValuesConfig[entityType.name][property.name];
       let chosenValue;
 
       if (Array.isArray(propertyConfig)) {
         //array of values
-        chosenValue = propertyConfig[Math.floor(Math.random() * propertyConfig.length)];
-        this._predefinedChosenValues[entityType.name][property.name].push(chosenValue);
+        chosenValue =
+          propertyConfig[Math.floor(Math.random() * propertyConfig.length)];
+        this._predefinedChosenValues[entityType.name][property.name].push(
+          chosenValue
+        );
         return chosenValue;
-      } else if (typeof propertyConfig === "string" && propertyConfig.indexOf("$ref") !== -1) {
+      } else if (
+        typeof propertyConfig === "string" &&
+        propertyConfig.indexOf("$ref") !== -1
+      ) {
         const variableName = propertyConfig.split(":")[1];
 
         if (this._variables && this._variables[variableName]) {
@@ -289,7 +367,9 @@ export class ODataMockGenerator {
 
           if (Array.isArray(variable)) {
             chosenValue = variable[Math.floor(Math.random() * variable.length)];
-            this._predefinedChosenValues[entityType.name][property.name].push(chosenValue);
+            this._predefinedChosenValues[entityType.name][property.name].push(
+              chosenValue
+            );
             return chosenValue;
           } else {
             return variable;
@@ -318,9 +398,19 @@ export class ODataMockGenerator {
             for (const i in entityType.properties) {
               if (entityType.properties[i].name === propertyConfig.reference) {
                 const emptyProperty = entityType.properties[i];
-                entity[emptyProperty.name] = this._generatePropertyValue(emptyProperty, iIndexParameter, entityType, entity);
+                entity[emptyProperty.name] = this._generatePropertyValue(
+                  emptyProperty,
+                  iIndexParameter,
+                  entityType,
+                  entity
+                );
                 //and run again for current
-                return this._generatePropertyValue(property, iIndexParameter, entityType, entity);
+                return this._generatePropertyValue(
+                  property,
+                  iIndexParameter,
+                  entityType,
+                  entity
+                );
               }
             }
           }
@@ -329,9 +419,10 @@ export class ODataMockGenerator {
     }
 
     // faker?
-    if (this._fakerConfig[entityType.name] &&
-      this._fakerConfig[entityType.name][property.name]) {
-
+    if (
+      this._fakerConfig[entityType.name] &&
+      this._fakerConfig[entityType.name][property.name]
+    ) {
       const fakerCall = this._fakerConfig[entityType.name][property.name];
       let generatedValue;
 
@@ -350,7 +441,9 @@ export class ODataMockGenerator {
 
         return generatedValue;
       } catch (error) {
-        throw new Error(`faker.js call error, check the config for ${entityType.name}/${property.name}`);
+        throw new Error(
+          `faker.js call error, check the config for ${entityType.name}/${property.name}`
+        );
       }
     }
 
@@ -358,13 +451,22 @@ export class ODataMockGenerator {
     let index = iIndexParameter;
 
     if (!index) {
-      index = Math.floor(this._dataGenerator.getPseudoRandomNumber("String") * 10000) + 101;
+      index =
+        Math.floor(
+          this._dataGenerator.getPseudoRandomNumber("String") * 10000
+        ) + 101;
     }
 
-    let value = this._dataGenerator.generateValueForODataProperty(property, index);
+    let value = this._dataGenerator.generateValueForODataProperty(
+      property,
+      index
+    );
 
     if (value === null) {
-      value = this._generateDataFromEntity(this._mComplexTypes[property.type], index);
+      value = this._generateDataFromEntity(
+        this._mComplexTypes[property.type],
+        index
+      );
     }
 
     return value;


### PR DESCRIPTION
Hi Jacek,

thanks a lot for your work. Pls check this PR.

- automated generation of refs between entities, without it i had a hard time using the lib
- I disabled per configure the "type" property, for some reason it is causing an endless loop between entities in the SAPUI

In general it seems to me this lib is unique, since no one else is generating data base on given metafile schema.

Hope all this works...

Thanks.