### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   coveralls:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wozjac/omg-odata-mock-generator/security/code-scanning/15](https://github.com/wozjac/omg-odata-mock-generator/security/code-scanning/15)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient because the workflow only reads repository contents (e.g., fetching code and coverage files) and does not perform any write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `coveralls` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
