### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/wozjac/omg-odata-mock-generator/security/code-scanning/16](https://github.com/wozjac/omg-odata-mock-generator/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily involves checking out the repository, setting up Node.js, installing dependencies, and building the project. These tasks only require `contents: read` permissions. We will add this block to the root of the workflow to apply it to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
